### PR TITLE
Fix weird transition

### DIFF
--- a/Pod/Classes/SideMenuNavigationController.swift
+++ b/Pod/Classes/SideMenuNavigationController.swift
@@ -265,7 +265,9 @@ open class SideMenuNavigationController: UINavigationController {
         super.viewWillTransition(to: size, with: coordinator)
         
         // Don't bother resizing if the view isn't visible
-        guard let transitionController = transitionController, !view.isHidden else { return }
+        guard let transitionController = transitionController, !view.isHidden,
+              UIApplication.shared.applicationState != UIApplication.State.background,
+              UIApplication.shared.applicationState != UIApplication.State.inactive else { return }
 
         rotating = true
         


### PR DESCRIPTION
Based on the fix of the PR #650 by @2h4u to fix the weird transition opening the app.
Adding the inactive case will fix the weird transition when the device is rotated